### PR TITLE
style: Fix over-indent for typical usage example

### DIFF
--- a/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/__main__.py
+++ b/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/__main__.py
@@ -1,6 +1,6 @@
 """The main file that is executed when this project is run as a module.
 
-    Typical usage example:
+Typical usage example::
 
     python -m module_name --version
 


### PR DESCRIPTION
From now on, if we indent code, use '::' on the line before the raw code